### PR TITLE
Fix incorrect score assignment

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -69,10 +69,10 @@ class Controller:
         for index,score in enumerate(self.current_criterion.scores):
                 print(f"{index}: {score}")
         
-        self.current_score = self.current_criterion.scores[int(k)]
 
     def edit_score_confirm(self,k=None):
         """Confirm changes to score"""
+        self.current_score = self.current_criterion.scores[int(k)]
         print(f"Updated score: {self.current_criterion.name} to: {self.current_score} and back to (applicant details)...\n")
         
         self.current_applicant.scores[self.current_criterion] = self.current_score

--- a/controller.py
+++ b/controller.py
@@ -10,7 +10,6 @@ class Controller:
         self.shortlist = load_shortlist(path)
         self.current_applicant = None
         self.current_criterion = None
-        self.current_score = None
         self.view = View()
         self.options = None
         self.options_home = {"r":self.show_role_info,
@@ -72,10 +71,9 @@ class Controller:
 
     def edit_score_confirm(self,k=None):
         """Confirm changes to score"""
-        self.current_score = self.current_criterion.scores[int(k)]
-        print(f"Updated score: {self.current_criterion.name} to: {self.current_score} and back to (applicant details)...\n")
+        print(f"Updated score: {self.current_criterion.name} to: {self.current_criterion.scores[int(k)]} and back to (applicant details)...\n")
         
-        self.current_applicant.scores[self.current_criterion] = self.current_score
+        self.current_applicant.scores[self.current_criterion] = self.current_criterion.scores[int(k)]
         self.view.view_applicant_details(self.current_applicant)
         self.options = self.options_applicant_detail
 


### PR DESCRIPTION
#29 the cause was current_score was assigned within the wrong function, so it used the same keypress from when you select the criteria. I didn't actually notice this, because admittedly, I wasn't thorough with testing and always used same keypress for both criteria and score selection... 